### PR TITLE
Removed unused 10px margins from select and text inputs

### DIFF
--- a/components/forms/_input-fields/input-field.scss
+++ b/components/forms/_input-fields/input-field.scss
@@ -64,7 +64,8 @@
     @extend .msds-text-body-3;
     color: $gray-9;
     margin-left: 3px;
-    margin-top: 0;
+    margin-top: 10px;
+    margin-bottom: 10px;
   }
   &--small {
     .msds-input__text-input {

--- a/components/forms/_input-fields/input-field.scss
+++ b/components/forms/_input-fields/input-field.scss
@@ -7,7 +7,6 @@
   position: relative;
   &__icon-wrapper {
     position: relative;
-    margin-bottom: 10px;
   }
   &__text-input {
     @extend .msds-text-body-1;

--- a/components/forms/_select-input/select-input.scss
+++ b/components/forms/_select-input/select-input.scss
@@ -1,6 +1,5 @@
 .msds-select-input {
   position: relative;
-  margin-bottom: 10px;
   &__select {
     width: 100%;
     padding-left: 20px;


### PR DESCRIPTION
The margin was added to the selects to make them consistent with text inputs.
However, the margin on the text inputs were likely never intended, as this type of margin should be added by the context in which it is used.