### PR TITLE
updated link definition on basic card to bold

### DIFF
--- a/components/button-cards/_basic-card/basic-card.scss
+++ b/components/button-cards/_basic-card/basic-card.scss
@@ -90,7 +90,7 @@
 
   &__link {
     @extend .msds-text-body-1;
-    @extend .msds-font-weight-light;
+    @extend .msds-font-weight-bold;
     color: $clear-blue;
 
     &:hover {


### PR DESCRIPTION
Updated link definition on the basic card to bold

The bottom link on basic cards is now bold instead of light.