### PR TITLE
Rich Icon size amendment

### DIFF
--- a/components/button-cards/_generic-card/generic-card.scss
+++ b/components/button-cards/_generic-card/generic-card.scss
@@ -33,6 +33,20 @@
         width: 100%;
       }
     }
+
+    &-rich-icon-container {
+      overflow: hidden;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+      margin-top: 20px;
+    }
+
+    &-rich-icon {
+      max-width: 173px;
+      max-height: 130px;
+    }
   }
 
   &__body {


### PR DESCRIPTION
I have added the necessary CSS definition to apply the Rich Icon size amendments on the generic card CSS definitions.